### PR TITLE
Fix Railway start command to install deps

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -5,7 +5,7 @@ builder = "nixpacks"
 NODE_ENV = "production"
 
 [deploy]
-startCommand = "cd server && npx prisma generate --schema=./prisma/schema.prisma && npx prisma migrate deploy --schema=./prisma/schema.prisma && SERVER_PORT=$PORT node index.js"
+startCommand = "cd server && npm install --omit=dev && npx prisma generate --schema=./prisma/schema.prisma && npx prisma migrate deploy --schema=./prisma/schema.prisma && SERVER_PORT=$PORT node index.js"
 healthcheckPath = "/api/ping"
 healthcheckTimeout = 30
 


### PR DESCRIPTION
## Summary
- update Railway start command to install server deps before running Prisma

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a24221da0832297f252c9541df2d4