### PR TITLE
Adjust Railway predeploy setup

### DIFF
--- a/RAILWAY.md
+++ b/RAILWAY.md
@@ -7,8 +7,12 @@ This file contains notes for deploying AnythingLLM on Railway.
 The `railway.toml` file has been configured to:
 
 1. Generate Prisma client before starting the server
-2. Apply database migrations 
-3. Start the server with the correct port mapping
+2. Apply database migrations
+3. Install server dependencies during a pre-deploy step
+4. Start the server with the correct port mapping
+
+> **Note**
+> Dependencies are installed during the pre-deploy step. Avoid running `npm install` again in the start command to prevent timeouts.
 
 ## Required Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ Mintplex Labs & the community maintain a number of deployment methods, scripts, 
 
 [or set up a production AnythingLLM instance without Docker →](./BARE_METAL.md)
 
+> **Railway Deployments**
+> The `railway.toml` file installs dependencies during the pre-deploy phase.
+> Avoid adding `npm install` to the start command to prevent startup timeouts.
+
 ## How to setup for development
 
 - `yarn setup` To fill in the required `.env` files you'll need in each of the application sections (from root of repo).

--- a/railway.toml
+++ b/railway.toml
@@ -5,7 +5,8 @@ builder = "nixpacks"
 NODE_ENV = "production"
 
 [deploy]
-startCommand = "cd server && npm install --omit=dev && npx prisma generate --schema=./prisma/schema.prisma && npx prisma migrate deploy --schema=./prisma/schema.prisma && SERVER_PORT=$PORT node index.js"
+preDeployCommand = "cd server && npm install --omit=dev"
+startCommand = "cd server && npx prisma generate --schema=./prisma/schema.prisma && npx prisma migrate deploy --schema=./prisma/schema.prisma && SERVER_PORT=$PORT node index.js"
 healthcheckPath = "/api/ping"
 healthcheckTimeout = 30
 


### PR DESCRIPTION
## Summary
- move `npm install` to Railway preDeploy step
- document new predeploy behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a3779bbe883228a881642ac0dcebb

## Summary by Sourcery

Move dependency installation to Railway pre-deploy phase and update related documentation to prevent startup timeouts

Deployment:
- Add a preDeployCommand in railway.toml to run `npm install --omit=dev` and remove it from the startCommand

Documentation:
- Document the new pre-deploy dependency installation behavior in RAILWAY.md
- Add notes in README.md about avoiding `npm install` in the start command on Railway