### PR TITLE
Fix React strict mode condition

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,7 +4,7 @@ import { BrowserRouter as Router } from "react-router-dom";
 import App from "@/App.jsx";
 import "@/index.css";
 const isDev = process.env.NODE_ENV !== "production";
-const REACTWRAP = isDev ? React.Fragment : React.StrictMode;
+const REACTWRAP = isDev ? React.StrictMode : React.Fragment;
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <REACTWRAP>


### PR DESCRIPTION
## Summary
- ensure `React.StrictMode` only in development to avoid hydration errors

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684fb054fae083228bbf93fa4cf869d5

## Summary by Sourcery

Bug Fixes:
- Restrict React.StrictMode wrapper to development environment to avoid hydration mismatches in production