### PR TITLE
Fix missing storage path fallback

### DIFF
--- a/server/endpoints/api/document/index.js
+++ b/server/endpoints/api/document/index.js
@@ -15,10 +15,12 @@ const fs = require("fs");
 const path = require("path");
 const { Document } = require("../../../models/documents");
 const { purgeFolder } = require("../../../utils/files/purgeDocument");
-const documentsPath =
+const baseStoragePath =
   process.env.NODE_ENV === "development"
-    ? path.resolve(__dirname, "../../../storage/documents")
-    : path.resolve(process.env.STORAGE_DIR, `documents`);
+    ? path.resolve(__dirname, "../../../storage")
+    : process.env.STORAGE_DIR || path.resolve(__dirname, "../../../storage");
+
+const documentsPath = path.resolve(baseStoragePath, "documents");
 
 function apiDocumentEndpoints(app) {
   if (!app) return;

--- a/server/jobs/helpers/index.js
+++ b/server/jobs/helpers/index.js
@@ -1,10 +1,12 @@
 const path = require('node:path');
 const fs = require('node:fs');
 const { parentPort } = require('node:worker_threads');
-const documentsPath =
+const baseStoragePath =
   process.env.NODE_ENV === "development"
-    ? path.resolve(__dirname, `../../storage/documents`)
-    : path.resolve(process.env.STORAGE_DIR, `documents`);
+    ? path.resolve(__dirname, "../../storage")
+    : process.env.STORAGE_DIR || path.resolve(__dirname, "../../storage");
+
+const documentsPath = path.resolve(baseStoragePath, "documents");
 
 function log(stringContent = '') {
   if (parentPort) parentPort.postMessage(`\x1b[33m[${process.pid}]\x1b[0m: ${stringContent}`); // running as worker

--- a/server/utils/DocumentManager/index.js
+++ b/server/utils/DocumentManager/index.js
@@ -1,10 +1,12 @@
 const fs = require("fs");
 const path = require("path");
 
-const documentsPath =
+const baseStoragePath =
   process.env.NODE_ENV === "development"
-    ? path.resolve(__dirname, `../../storage/documents`)
-    : path.resolve(process.env.STORAGE_DIR, `documents`);
+    ? path.resolve(__dirname, "../../storage")
+    : process.env.STORAGE_DIR || path.resolve(__dirname, "../../storage");
+
+const documentsPath = path.resolve(baseStoragePath, "documents");
 
 class DocumentManager {
   constructor({ workspace = null, maxTokens = null }) {

--- a/server/utils/agents/imported.js
+++ b/server/utils/agents/imported.js
@@ -3,10 +3,12 @@ const path = require("path");
 const { safeJsonParse } = require("../http");
 const { isWithin, normalizePath } = require("../files");
 const { CollectorApi } = require("../collectorApi");
-const pluginsPath =
+const baseStoragePath =
   process.env.NODE_ENV === "development"
-    ? path.resolve(__dirname, "../../storage/plugins/agent-skills")
-    : path.resolve(process.env.STORAGE_DIR, "plugins", "agent-skills");
+    ? path.resolve(__dirname, "../../storage")
+    : process.env.STORAGE_DIR || path.resolve(__dirname, "../../storage");
+
+const pluginsPath = path.resolve(baseStoragePath, "plugins", "agent-skills");
 const sharedWebScraper = new CollectorApi();
 
 class ImportedPlugin {

--- a/server/utils/files/index.js
+++ b/server/utils/files/index.js
@@ -3,14 +3,13 @@ const path = require("path");
 const { v5: uuidv5 } = require("uuid");
 const { Document } = require("../../models/documents");
 const { DocumentSyncQueue } = require("../../models/documentSyncQueue");
-const documentsPath =
+const baseStoragePath =
   process.env.NODE_ENV === "development"
-    ? path.resolve(__dirname, `../../storage/documents`)
-    : path.resolve(process.env.STORAGE_DIR, `documents`);
-const vectorCachePath =
-  process.env.NODE_ENV === "development"
-    ? path.resolve(__dirname, `../../storage/vector-cache`)
-    : path.resolve(process.env.STORAGE_DIR, `vector-cache`);
+    ? path.resolve(__dirname, "../../storage")
+    : process.env.STORAGE_DIR || path.resolve(__dirname, "../../storage");
+
+const documentsPath = path.resolve(baseStoragePath, "documents");
+const vectorCachePath = path.resolve(baseStoragePath, "vector-cache");
 
 // Should take in a folder that is a subfolder of documents
 // eg: youtube-subject/video-123.json

--- a/server/utils/files/multer.js
+++ b/server/utils/files/multer.js
@@ -10,10 +10,11 @@ const { normalizePath } = require(".");
  */
 const fileUploadStorage = multer.diskStorage({
   destination: function (_, __, cb) {
-    const uploadOutput =
+    const baseStoragePath =
       process.env.NODE_ENV === "development"
-        ? path.resolve(__dirname, `../../../collector/hotdir`)
-        : path.resolve(process.env.STORAGE_DIR, `../../collector/hotdir`);
+        ? path.resolve(__dirname, "../../")
+        : process.env.STORAGE_DIR || path.resolve(__dirname, "../../");
+    const uploadOutput = path.resolve(baseStoragePath, "collector/hotdir");
     cb(null, uploadOutput);
   },
   filename: function (_, file, cb) {
@@ -30,10 +31,11 @@ const fileUploadStorage = multer.diskStorage({
  */
 const fileAPIUploadStorage = multer.diskStorage({
   destination: function (_, __, cb) {
-    const uploadOutput =
+    const baseStoragePath =
       process.env.NODE_ENV === "development"
-        ? path.resolve(__dirname, `../../../collector/hotdir`)
-        : path.resolve(process.env.STORAGE_DIR, `../../collector/hotdir`);
+        ? path.resolve(__dirname, "../../")
+        : process.env.STORAGE_DIR || path.resolve(__dirname, "../../");
+    const uploadOutput = path.resolve(baseStoragePath, "collector/hotdir");
     cb(null, uploadOutput);
   },
   filename: function (_, file, cb) {
@@ -47,10 +49,11 @@ const fileAPIUploadStorage = multer.diskStorage({
 // Asset storage for logos
 const assetUploadStorage = multer.diskStorage({
   destination: function (_, __, cb) {
-    const uploadOutput =
+    const baseStoragePath =
       process.env.NODE_ENV === "development"
-        ? path.resolve(__dirname, `../../storage/assets`)
-        : path.resolve(process.env.STORAGE_DIR, "assets");
+        ? path.resolve(__dirname, "../../storage")
+        : process.env.STORAGE_DIR || path.resolve(__dirname, "../../storage");
+    const uploadOutput = path.resolve(baseStoragePath, "assets");
     fs.mkdirSync(uploadOutput, { recursive: true });
     return cb(null, uploadOutput);
   },
@@ -67,10 +70,11 @@ const assetUploadStorage = multer.diskStorage({
  */
 const pfpUploadStorage = multer.diskStorage({
   destination: function (_, __, cb) {
-    const uploadOutput =
+    const baseStoragePath =
       process.env.NODE_ENV === "development"
-        ? path.resolve(__dirname, `../../storage/assets/pfp`)
-        : path.resolve(process.env.STORAGE_DIR, "assets/pfp");
+        ? path.resolve(__dirname, "../../storage")
+        : process.env.STORAGE_DIR || path.resolve(__dirname, "../../storage");
+    const uploadOutput = path.resolve(baseStoragePath, "assets/pfp");
     fs.mkdirSync(uploadOutput, { recursive: true });
     return cb(null, uploadOutput);
   },


### PR DESCRIPTION
## Summary
- fix fallback to built-in storage path when `STORAGE_DIR` not set
- normalize storage path usage in document helpers and upload handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850b20a4e208322ad04e992c3d5986e

## Summary by Sourcery

Fix missing fallback for STORAGE_DIR and standardize storage path resolution across modules

Bug Fixes:
- Add fallback to built-in local storage when STORAGE_DIR environment variable is not set

Enhancements:
- Introduce baseStoragePath logic to unify development and production storage directory resolution
- Refactor multer storage configurations to derive upload destinations (collector/hotdir, assets, assets/pfp) from baseStoragePath
- Normalize document and vector cache path computation in file utilities, API endpoints, job helpers, DocumentManager, and agent import modules