### PR TITLE
Fix Prisma schema path for Railway

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,7 +4,7 @@ buildCommand = "echo '[RAILWAY] Build starting...' && npm install -g yarn && cd 
 
 [deploy]
 root = "server"
-startCommand = "echo '[RAILWAY] Starting Prisma operations...' && npx prisma generate --schema=./prisma/schema.prisma && echo '[RAILWAY] Prisma generate completed' && (npx prisma migrate deploy --schema=./prisma/schema.prisma || echo '[RAILWAY] Migrate failed but continuing...') && echo '[RAILWAY] Prisma migrate completed' && echo '[RAILWAY] Starting Node.js server...' && node index.js"
+startCommand = "echo '[RAILWAY] Starting Prisma operations...' && npx prisma generate --schema=./server/prisma/schema.prisma && echo '[RAILWAY] Prisma generate completed' && (npx prisma migrate deploy --schema=./server/prisma/schema.prisma || echo '[RAILWAY] Migrate failed but continuing...') && echo '[RAILWAY] Prisma migrate completed' && echo '[RAILWAY] Starting Node.js server...' && node server/index.js"
 healthcheckPath = "/api/ping"
 healthcheckTimeout = 180
 healthcheckInterval = 10


### PR DESCRIPTION
## Summary
- ensure Railway deploy runs Prisma from project root

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850d764c0c883228692f280418e5f97

## Summary by Sourcery

Fix the Railway deployment configuration to run Prisma commands from the correct project root and start the server from the server directory

Build:
- Update startCommand in railway.toml to reference server/prisma/schema.prisma instead of ./prisma/schema.prisma
- Adjust the Node.js startup path in the startCommand to use server/index.js