### PR TITLE
Fix start command path for Railway deployments

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,6 +5,8 @@
     "dockerfilePath": "Dockerfile"
   },
   "deploy": {
+    "root": "server",
+    "startCommand": "cd server && npx prisma migrate deploy && node index.js",
     "healthcheckPath": "/api/ping",
     "healthcheckTimeout": 100,
     "numReplicas": 1,

--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,8 @@ builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
 
 [deploy]
+root = "server"
+startCommand = "cd server && npx prisma migrate deploy && node index.js"
 healthcheckPath = "/api/ping"
 healthcheckTimeout = 180
 healthcheckInterval = 10


### PR DESCRIPTION
## Summary
- update `railway.toml` with proper working directory and Prisma migration command
- add matching settings in `railway.json`

## Testing
- `yarn lint` *(fails: prettier not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e1415d6883229b550d3943325631

## Summary by Sourcery

Update Railway deployment configuration to use the server subdirectory as the root and run Prisma migrations before starting the application.

Enhancements:
- Set 'server' as the root directory and prepend Prisma migration deploy to the startCommand in railway.toml
- Mirror the updated root directory and startCommand settings in railway.json